### PR TITLE
 [CI/CD] EC2 Pull-only 배포를 위한 분리 및 CD ENV 관리방법 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,10 +58,6 @@ jobs:
           script: |
             set -e
             cd '${{ env.DEPLOY_PATH }}'
-            cat > .env <<'EOF'
-            ${{ secrets.EC2_ENV_FILE }}
-            EOF
-            chmod 600 .env
             export IMAGE_TAG='${{ steps.vars.outputs.image_tag }}'
             docker compose pull
             docker compose up -d --remove-orphans


### PR DESCRIPTION
## 1. 개요
- 관련 이슈: #44 

## 2. 작업 내용
- 운영 정책 변경에 따라 CD 내 EC2 `.env` 자동 생성 로직 제거(EC2에서 `.env` 직접 관리)

## 3. AI 활용 및 검증
- [x] AI가 생성한 코드 포함
- [ ] 100% 직접 작성

- 검증 방법: 필수 시크릿(`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`)만 사용되는지 확인

## 4. 스크린샷 (선택)
- 없음

## 5. 체크리스트
- [x] `uv run pre-commit run --all-files`를 실행하여 통과했는가?
- [x] 스스로 코드를 한 번 리뷰했는가? (AI가 짠 코드 맹신 금지)
- [x] 불필요한 주석이나 print 문을 제거했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우에서 원격 환경 설정 파일 자동 생성 단계를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->