### PR TITLE
[Fix] 채팅 콜백 modified_itinerary에서 planning_preference 필드 제거

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -72,11 +72,17 @@ async def run_chat_pipeline(request: ChatRequest) -> ChatResponse:
 def _serialize_itinerary(itinerary: Any) -> dict | None:
     if itinerary is None:
         return None
+    serialized: dict | None = None
     if isinstance(itinerary, BaseModel):
-        return itinerary.model_dump(mode="json")
-    if isinstance(itinerary, dict):
-        return itinerary
-    return None
+        serialized = itinerary.model_dump(mode="json")
+    elif isinstance(itinerary, dict):
+        serialized = dict(itinerary)
+
+    if serialized is None:
+        return None
+
+    serialized.pop("planning_preference", None)
+    return serialized
 
 
 def _build_callback_payload(result: ChatResponse) -> dict:


### PR DESCRIPTION
## 1. 개요
- 관련 이슈: #55

## 2. 작업 내용
- Python -> Nest 채팅 결과 콜백 payload 직렬화 로직에서 `modified_itinerary.planning_preference`를 제거하도록 수정
- `BaseModel`/`dict` 모두 동일하게 처리되도록 `_serialize_itinerary` 경로를 정리하여 콜백 스키마 일관성 확보

## 3. AI 활용 및 검증
- [x] AI가 생성한 코드 포함
- [ ] 100% 직접 작성

- 검증 방법:
  - 변경 파일(`app/services/chat_service.py`) 기준 diff 수동 리뷰
  - 직렬화 결과에서 `planning_preference`가 제외되는 코드 경로 확인
  - 원격 브랜치 푸시 후 PR 기준 재검토

## 4. 스크린샷 (선택)
- 없음

## 5. 체크리스트
- [x] `uv run pre-commit run --all-files`를 실행하여 통과했는가?
- [x] 스스로 코드를 한 번 리뷰했는가? (AI가 짠 코드 맹신 금지)
- [x] 불필요한 주석이나 print 문을 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 서비스의 여행 일정 데이터 처리 방식을 개선하여 일관성 있는 직렬화 처리를 구현했습니다.
  * 여행 일정 데이터에서 불필요한 설정 정보가 제거되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->