### PR TITLE
[Fix] 서버 부팅 시 HMAC_SECRET 환경변수 에러 방지

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     OPENAI_API_KEY: str
     SERVICE_SECRET: str
-    HMAC_SECRET: str
+    HMAC_SECRET: str | None = None
     LLM_MODEL_NAME: str = "gpt-4o-mini"
     ENABLE_STAGE_LLM_ROUTING: bool = False
     LLM_MODEL_QUALITY: str = "gpt-4o-mini"


### PR DESCRIPTION
 ## 1. 개요
 - 관련 이슈: #69 관련 후속 조치)
    ## 2. 작업 내용
     - `app/core/config.py`의 `Settings` 클래스에서 `HMAC_SECRET`을 필수 필드(`str`)에서 선택 필드(`str | None = None`)로 변경했습니다.
     - 이를 통해 서버 배포나 로컬 환경 세팅 시 `.env` 파일에 해당 키가 누락되어도 앱 부팅 과정에서 크래시(Crash)가 발생하는 문제를 방지합니다.
     - 실제 해싱 로직이 실행되는 시점(`process_chat_request`, `google_places_service`)에 값이 없을 때만 명시적으로 예외(`ValueError`)를 던지도록 하여 보안 상의
      요구사항("fail loudly if missing")은 그대로 유지했습니다.
    
     ## 3. AI 활용 및 검증
    - [x] AI가 생성한 코드 포함
    - [ ] 100% 직접 작성
   
    - 검증 방법:
      - `HMAC_SECRET`이 `.env`에 없는 상태로 서버가 정상적으로 부팅되는지 확인.
      - `pytest tests/`를 통해 관련 유닛 테스트들이 모두 정상 통과함을 확인.
   
   ## 4. 스크린샷 (선택)
   (생략)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **설정**
  * HMAC_SECRET 설정이 이제 선택 사항으로 변경되었습니다. 환경 변수를 설정하지 않아도 애플리케이션을 시작할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->