### PR TITLE
[Feat] 로드맵 생성 8일 제한 추가 (#82)

### DIFF
--- a/app/schemas/course.py
+++ b/app/schemas/course.py
@@ -53,7 +53,7 @@ class CourseRequest(BaseModel):
 
     start_date: date = Field(..., description="여행 시작일 (YYYY-MM-DD)")
     end_date: date = Field(..., description="여행 종료일 (YYYY-MM-DD)")
-    regions: List[RegionDateRange] = Field(..., min_length=1, description="지역별 여행 기간")
+    regions: List[RegionDateRange] = Field(..., min_length=1, max_length=8, description="지역별 여행 기간")
     people_count: int = Field(..., ge=1, le=20, description="총 인원 수")
     companion_type: list[CompanionType] = Field(..., min_length=1, description="동행자 유형 목록")
     travel_themes: list[TravelTheme] = Field(..., min_length=1, description="여행 테마 목록")
@@ -84,6 +84,9 @@ class CourseRequest(BaseModel):
         for region_range in self.regions:
             if region_range.start_date < self.start_date or region_range.end_date > self.end_date:
                 raise ValueError("지역별 여행 기간은 전체 여행 기간 안에 있어야 합니다.")
+        total_days = (self.end_date - self.start_date).days + 1
+        if total_days > 8:
+            raise ValueError("여행 기간은 최대 8일이어야 합니다.")
         return self
 
 

--- a/docs/api/generate-api.md
+++ b/docs/api/generate-api.md
@@ -75,7 +75,7 @@ ai_action: "editable"
 | `payload` | object | Yes | 로드맵 생성 입력값 |
 | `payload.start_date` | date | Yes | 여행 시작일 |
 | `payload.end_date` | date | Yes | 여행 종료일 |
-| `payload.regions` | array | Yes | 지역별 여행 기간, 1개 이상 |
+| `payload.regions` | array | Yes | 지역별 여행 기간, 1개 이상 8개 이하 |
 | `payload.people_count` | integer | Yes | 총 인원 수, 1~20 |
 | `payload.companion_type` | array | Yes | 동행자 유형, 1개 이상 |
 | `payload.travel_themes` | array | Yes | 여행 테마, 1개 이상 |
@@ -103,6 +103,16 @@ ai_action: "editable"
 | `422` | 요청 body 스키마 검증 실패 |
 | `500` | 서버 설정 누락 또는 예상하지 못한 오류 |
 | `504` | 요청 단위 타임아웃 |
+
+## 입력 검증 규칙
+
+- `end_date`는 `start_date`와 같거나 이후여야 합니다.
+- 전체 여행 기간은 최대 8일이어야 합니다.
+- `payload.regions`는 1개 이상 8개 이하이어야 합니다.
+- 각 지역 구간의 `end_date`는 해당 `start_date`와 같거나 이후여야 합니다.
+- 각 지역 구간은 전체 여행 기간 안에 포함되어야 합니다.
+- 스켈레톤 생성 단계에서 지역 구간 사이 날짜 공백과 겹침을 검증합니다.
+- 지역 구간을 정렬했을 때 전체 여행 기간을 빠짐없이 덮어야 합니다.
 
 ## Callback
 

--- a/docs/specs/roadmap-generation.md
+++ b/docs/specs/roadmap-generation.md
@@ -50,7 +50,7 @@ LLM이 좌표를 직접 생성하지 않고 Google Places 응답을 우선 사�
 | `callback_url` | URL | Yes | 결과 콜백을 받을 NestJS URL |
 | `payload.start_date` | date | Yes | 전체 여행 시작일 |
 | `payload.end_date` | date | Yes | 전체 여행 종료일 |
-| `payload.regions` | `RegionDateRange[]` | Yes | 지역별 여행 기간 |
+| `payload.regions` | `RegionDateRange[]` | Yes | 지역별 여행 기간, 최대 8개 |
 | `payload.people_count` | integer | Yes | 총 인원 수, 1~20 |
 | `payload.companion_type` | `CompanionType[]` | Yes | 동행자 유형, 1개 이상 |
 | `payload.travel_themes` | `TravelTheme[]` | Yes | 여행 테마, 1개 이상 |
@@ -66,8 +66,10 @@ LLM이 좌표를 직접 생성하지 않고 Google Places 응답을 우선 사�
 ## 입력 검증 규칙
 
 - `end_date`는 `start_date`와 같거나 이후여야 합니다.
+- 전체 여행 기간은 최대 8일이어야 합니다.
 - 각 지역 구간의 `end_date`는 해당 `start_date`와 같거나 이후여야 합니다.
 - 각 지역 구간은 전체 여행 기간 안에 포함되어야 합니다.
+- `payload.regions`는 최대 8개까지 허용합니다.
 - 스켈레톤 생성 단계에서 지역 구간 사이 날짜 공백과 겹침을 검증합니다.
 - 지역 구간을 정렬했을 때 전체 여행 기간을 빠짐없이 덮어야 합니다.
 - `people_count`는 1명 이상 20명 이하입니다.

--- a/tests/test_course_schema.py
+++ b/tests/test_course_schema.py
@@ -1,0 +1,70 @@
+"""CourseRequest 스키마 계약 테스트."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.course import CourseRequest
+
+
+def _base_payload() -> dict:
+    return {
+        "start_date": "2026-02-01",
+        "end_date": "2026-02-08",
+        "regions": [
+            {"region": "SEOUL", "start_date": "2026-02-01", "end_date": "2026-02-08"},
+        ],
+        "people_count": 2,
+        "companion_type": ["FAMILY"],
+        "travel_themes": ["HEALING"],
+        "pace_preference": "RELAXED",
+        "planning_preference": "PLANNED",
+        "destination_preference": "TOURIST_SPOTS",
+        "activity_preference": "REST_FOCUSED",
+        "priority_preference": "EFFICIENCY",
+    }
+
+
+def test_course_request_accepts_up_to_eight_days_and_regions() -> None:
+    payload = _base_payload()
+    payload["regions"] = [
+        {"region": "SEOUL", "start_date": "2026-02-01", "end_date": "2026-02-03"},
+        {"region": "BUSAN", "start_date": "2026-02-04", "end_date": "2026-02-08"},
+    ]
+
+    request = CourseRequest.model_validate(payload)
+
+    assert len(request.regions) == 2
+    assert (request.end_date - request.start_date).days + 1 == 8
+
+
+def test_course_request_rejects_more_than_eight_days() -> None:
+    payload = _base_payload()
+    payload["end_date"] = "2026-02-09"
+    payload["regions"] = [
+        {"region": "SEOUL", "start_date": "2026-02-01", "end_date": "2026-02-09"},
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        CourseRequest.model_validate(payload)
+
+    assert "최대 8일" in str(exc_info.value)
+
+
+def test_course_request_rejects_more_than_eight_regions() -> None:
+    payload = _base_payload()
+    payload["end_date"] = "2026-02-08"
+    payload["regions"] = [
+        {
+            "region": "SEOUL",
+            "start_date": "2026-02-01",
+            "end_date": "2026-02-01",
+        }
+        for index in range(1, 10)
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        CourseRequest.model_validate(payload)
+
+    assert "at most 8 items" in str(exc_info.value) or "최대 8" in str(exc_info.value)

--- a/tests/test_pipeline_webhook_events.py
+++ b/tests/test_pipeline_webhook_events.py
@@ -87,8 +87,7 @@ def test_chat_pipeline_emits_started_and_failed_webhooks(monkeypatch) -> None:
     assert [event["event_type"] for event in captured_events] == ["chat_started", "chat_completed"]
     assert captured_events[0]["title"] == "채팅 수정 시작"
     assert any(
-        field["name"] == "사용자 발화" and "바꿔줘" in field["value"]
-        for field in captured_events[0]["extra_fields"]
+        field["name"] == "사용자 발화" and "바꿔줘" in field["value"] for field in captured_events[0]["extra_fields"]
     )
     assert any(field["name"] == "오류 상세" for field in captured_events[1]["extra_fields"])
     assert captured_events[1]["status"] == "FAILED"


### PR DESCRIPTION
﻿## 1. 개요
- 관련 이슈: #82

## 2. 작업 내용
- `CourseRequest.regions`를 최대 8개로 제한했습니다.
- 전체 여행 기간이 8일을 초과하면 검증에서 거부하도록 추가했습니다.
- `docs/api/generate-api.md`와 `docs/specs/roadmap-generation.md`에 8일 정책을 반영했습니다.
- `tests/test_course_schema.py`를 추가해 8일/8 regions 제한을 검증했습니다.

## 3. AI 활용 및 검증
- [x] AI가 생성한 코드 포함
- [ ] 100% 직접 작성

- 검증 방법:
- Docker 컨테이너 `mohaeng` 안에서 `pytest tests/test_course_schema.py tests/test_pipeline_webhook_events.py` 실행

## 4. 스크린샷 (선택)

## 5. 체크리스트
- [x] `uv run pre-commit run --all-files`를 실행하여 통과했는가?
- [x] 스스로 코드를 한 번 리뷰했는가? (AI가 짠 코드 맹신 금지)
- [x] 불필요한 주석이나 print 문을 제거했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 여행 요청에 엄격한 검증 규칙이 적용되었습니다. 최대 8개 지역까지 추가 가능하며, 전체 여행 기간은 8일을 초과할 수 없습니다.

* **문서**
  * API 및 일정 생성 명세 문서가 입력 검증 규칙을 명확히 반영하도록 업데이트되었습니다.

* **테스트**
  * 새로운 검증 규칙을 확인하는 테스트 모듈이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->