### PR TITLE
[Feat] 채팅 수정 visit_time LLM 결정 정책 개선 (#95)

### DIFF
--- a/app/core/visit_time_llm.py
+++ b/app/core/visit_time_llm.py
@@ -20,7 +20,7 @@ class VisitTimeProposalSlot(BaseModel):
     """방문 순서별 visit_time 제안."""
 
     visit_sequence: int = Field(..., ge=1, description="방문 순서")
-    visit_time: str | None = Field(None, description="방문 시각 (HH:MM, 24시간)")
+    visit_time: str | None = Field(None, description="방문 시각 (08:00~24:00 범위의 24시간 HH:MM)")
 
 
 class VisitTimeProposalDay(BaseModel):
@@ -109,10 +109,15 @@ async def propose_visit_times_for_days(
 
     system_prompt = (
         "당신은 여행 일정의 visit_time을 배치하는 전문가입니다.\n"
-        "출력은 JSON만 반환하고, visit_time은 24시간 HH:MM 형식을 사용하세요.\n"
-        "visit_sequence 순서를 지키고 시간은 동일하거나 감소하지 않도록 점진적으로 증가해야 합니다.\n"
+        "출력은 JSON만 반환하고, visit_time은 반드시 24시간 HH:MM 형식을 사용하세요.\n"
+        "visit_time은 반드시 08:00 이상 24:00 이하로 출력하세요.\n"
+        "08:00보다 이른 시간과 24:00보다 늦은 시간은 절대 출력하지 마세요.\n"
+        "24:00은 하루 종료 시각으로만 사용할 수 있고 24:01, 25:00 같은 값은 금지입니다.\n"
+        "visit_sequence 순서를 지키고 시간이 감소하지 않도록 동일하거나 점진적으로 증가해야 합니다.\n"
+        "동일한 일차에서 최대 10개 장소까지 자연스럽고 현실적으로 배치하세요.\n"
         "section_hint, time_hint는 참고용이며 이동 동선을 고려해 자연스럽게 배치하세요.\n"
-        "입력에 없는 장소를 추가하거나 순서를 바꾸지 마세요."
+        "입력에 없는 장소를 추가하거나 순서를 바꾸지 마세요.\n"
+        "운영시간 데이터가 없으므로 실제 영업시간을 단정하지 마세요."
     )
     user_prompt = (
         "아래 일정 데이터의 각 장소에 대한 visit_time을 제안해주세요.\n"

--- a/app/core/visit_time_policy.py
+++ b/app/core/visit_time_policy.py
@@ -2,30 +2,17 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 
 from app.core.config import Settings, get_settings
 
-_SECTION_TIME_MAP = {
-    "MORNING": "09:00",
-    "LUNCH": "12:00",
-    "AFTERNOON": "14:00",
-    "DINNER": "18:00",
-    "EVENING": "20:00",
-    "NIGHT": "22:00",
-}
-_SEQUENCE_TIME_MAP = {
-    1: "09:00",
-    2: "12:00",
-    3: "14:00",
-    4: "18:00",
-    5: "20:00",
-    6: "22:00",
-    7: "23:00",
-}
-
 _DEFAULT_START = "09:00"
+_MIN_VISIT_TIME_MINUTES = 8 * 60
+_MAX_VISIT_TIME_MINUTES = 24 * 60
+_FALLBACK_END_MINUTES = 24 * 60
+_HHMM_PATTERN = re.compile(r"^(?P<hour>\d{2}):(?P<minute>\d{2})$")
 
 
 class VisitTimeOutputMode(StrEnum):
@@ -67,6 +54,9 @@ def parse_time_to_hhmm_minutes(value: str | None) -> int | None:
     elif is_am and hour == 12:
         hour = 0
 
+    if hour == 24 and minute == 0:
+        return _MAX_VISIT_TIME_MINUTES
+
     if not (0 <= hour < 24 and 0 <= minute < 60):
         return None
     return hour * 60 + minute
@@ -74,7 +64,9 @@ def parse_time_to_hhmm_minutes(value: str | None) -> int | None:
 
 def format_minutes_to_hhmm(total_minutes: int) -> str:
     """분 단위 시간을 HH:MM으로 포맷합니다."""
-    normalized = max(0, int(total_minutes))
+    normalized = max(0, min(int(total_minutes), _MAX_VISIT_TIME_MINUTES))
+    if normalized == _MAX_VISIT_TIME_MINUTES:
+        return "24:00"
     hour = (normalized // 60) % 24
     minute = normalized % 60
     return f"{hour:02d}:{minute:02d}"
@@ -127,16 +119,43 @@ def _format_visit_time(total_minutes: int, output_mode: VisitTimeOutputMode) -> 
     return format_minutes_to_hhmm(total_minutes)
 
 
-def _sequence_minutes(sequence: int, config: VisitTimePolicyConfig) -> int:
-    mapped = _SEQUENCE_TIME_MAP.get(sequence)
-    if mapped is not None:
-        parsed = parse_time_to_hhmm_minutes(mapped)
-        if parsed is not None:
-            return parsed
+def _is_hhmm_24h(value: str) -> bool:
+    match = _HHMM_PATTERN.match(value)
+    if not match:
+        return False
 
-    last_sequence = max(_SEQUENCE_TIME_MAP)
-    last_mapped = parse_time_to_hhmm_minutes(_SEQUENCE_TIME_MAP[last_sequence])
-    return last_mapped if last_mapped is not None else config.start_minutes
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute"))
+    if hour == 24:
+        return minute == 0
+    return 0 <= hour < 24 and 0 <= minute < 60
+
+
+def _parse_valid_visit_time(value: str | None) -> int | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not _is_hhmm_24h(text):
+        return None
+
+    parsed = parse_time_to_hhmm_minutes(text)
+    if parsed is None:
+        return None
+    if not (_MIN_VISIT_TIME_MINUTES <= parsed <= _MAX_VISIT_TIME_MINUTES):
+        return None
+    return parsed
+
+
+def _fallback_minutes_for_position(index: int, total_count: int, config: VisitTimePolicyConfig) -> int:
+    start = max(_MIN_VISIT_TIME_MINUTES, min(config.start_minutes, _MAX_VISIT_TIME_MINUTES))
+    count = max(1, total_count)
+    if count == 1:
+        return start
+
+    available_minutes = max(0, _FALLBACK_END_MINUTES - start)
+    step = max(1, available_minutes // count)
+    return min(_MAX_VISIT_TIME_MINUTES, start + max(0, index) * step)
 
 
 def apply_visit_time_policy(
@@ -147,13 +166,17 @@ def apply_visit_time_policy(
     llm_proposals_by_sequence: dict[int, str] | None = None,
     output_mode: VisitTimeOutputMode | str = VisitTimeOutputMode.HHMM,
 ) -> tuple[list[dict], list[str]]:
-    """visit_sequence 기반 고정 visit_time 정책을 적용합니다."""
+    """LLM 제안을 검증해 visit_time을 결정하고 실패 구간은 안전하게 보정합니다."""
     if not places:
         return places, []
 
     resolved_config = config or build_visit_time_policy_config()
     resolved_output_mode = _normalize_output_mode(output_mode)
-    _ = day_number, llm_proposals_by_sequence
+    proposals_provided = llm_proposals_by_sequence is not None
+    proposals = llm_proposals_by_sequence or {}
+    warnings: list[str] = []
+    previous_minutes: int | None = None
+    total_count = len(places)
 
     for index, place in enumerate(places):
         sequence_raw = place.get("visit_sequence")
@@ -162,9 +185,33 @@ def apply_visit_time_policy(
         except (TypeError, ValueError):
             sequence = index + 1
 
-        assigned_time = _sequence_minutes(sequence, resolved_config)
+        assigned_time: int | None = None
+        if resolved_output_mode == VisitTimeOutputMode.HHMM and proposals_provided:
+            proposed_time = proposals.get(sequence)
+            proposed_minutes = _parse_valid_visit_time(proposed_time)
+            if proposed_time and proposed_minutes is None:
+                warnings.append(
+                    f"day={day_number} sequence={sequence} invalid_visit_time={proposed_time!r}; fallback applied"
+                )
+            elif proposed_minutes is not None and previous_minutes is not None and proposed_minutes < previous_minutes:
+                warnings.append(
+                    f"day={day_number} sequence={sequence} decreasing_visit_time={proposed_time!r}; fallback applied"
+                )
+            else:
+                assigned_time = proposed_minutes
+
+            if assigned_time is None and sequence not in proposals:
+                warnings.append(f"day={day_number} sequence={sequence} missing_visit_time; fallback applied")
+
+        if assigned_time is None:
+            assigned_time = _fallback_minutes_for_position(index, total_count, resolved_config)
+
+        if previous_minutes is not None and assigned_time < previous_minutes:
+            assigned_time = previous_minutes
+
         place["visit_time"] = _format_visit_time(assigned_time, resolved_output_mode)
         place.pop("section", None)
         place.pop("section_hint", None)
+        previous_minutes = assigned_time
 
-    return places, []
+    return places, warnings

--- a/app/graph/chat/nodes/propose_visit_time.py
+++ b/app/graph/chat/nodes/propose_visit_time.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.core.visit_time_llm import propose_visit_times_for_days
 from app.graph.chat.state import ChatState
+from app.schemas.enums import PlanningPreference
 
 
 def _extract_modified_days(diff_keys: list[str]) -> set[int]:
@@ -23,6 +24,9 @@ async def propose_visit_time(state: ChatState) -> ChatState:
     itinerary = state.get("modified_itinerary")
     if not itinerary:
         return {**state, "error": "propose_visit_time에는 modified_itinerary가 필요합니다."}
+
+    if itinerary.get("planning_preference") != PlanningPreference.PLANNED:
+        return {**state, "visit_time_proposals": {}}
 
     modified_days = _extract_modified_days(state.get("diff_keys", []))
     if not modified_days:

--- a/docs/api/generate-api.md
+++ b/docs/api/generate-api.md
@@ -160,9 +160,9 @@ ai_action: "editable"
 Google Places 원본 `primaryType`과 `types`는 내부 분류에만 사용하고 최종 콜백에는 포함하지 않습니다.
 알 수 없는 유형은 `OTHER`로 전달합니다.
 일자별 장소 순서는 FOOD 장소를 anchor로 고정한 내부 동선 최적화 결과이며, `visit_sequence`와 `visit_time`은 최종 순서 기준으로 재계산됩니다.
-`planning_preference`가 `PLANNED`이면 `visit_time`은 `visit_sequence` 기준 고정 `HH:MM` 값으로 전달됩니다.
-현재 매핑은 `1 -> 09:00`, `2 -> 12:00`, `3 -> 14:00`, `4 -> 18:00`, `5 -> 20:00`, `6 -> 22:00`, `7 이상 -> 23:00`입니다.
-`SPONTANEOUS`이면 같은 순서 매핑을 `MORNING`/`LUNCH` 같은 section label 형식으로 변환해 전달합니다.
+`planning_preference`가 `PLANNED`이면 `visit_time`은 `08:00` 이상 `24:00` 이하의 `HH:MM` 값으로 전달됩니다.
+로드맵 생성 파이프라인은 별도 visit_time LLM 제안을 호출하지 않고, 최종 방문 순서와 장소 수를 기준으로 공용 fallback 분배 정책을 적용합니다.
+`SPONTANEOUS`이면 같은 fallback 분배 결과를 `MORNING`/`LUNCH` 같은 section label 형식으로 변환해 전달합니다.
 `visit_time` 계산에는 좌표 기반 이동시간이나 체류시간을 반영하지 않습니다.
 anchor 여부나 최적화 점수 같은 내부 판단값은 콜백에 포함하지 않습니다.
 

--- a/docs/architecture/roadmap-chat-server-communication.md
+++ b/docs/architecture/roadmap-chat-server-communication.md
@@ -190,6 +190,9 @@ sequenceDiagram
 - 교체/추가 장소의 Google Places `primaryType`과 `types`는 내부 정적 매핑으로 `place_category`를 산출하는 데만 사용합니다.
 - Google Places 원본 `primary_type`과 식사 anchor 판단값 같은 내부 힌트는 콜백에 포함하지 않습니다.
 - 하루 장소 수는 최소 1개, 최대 10개를 기준으로 합니다.
+- `planning_preference == PLANNED`이면 수정된 일차에 대해 LLM visit_time 제안을 생성하고, 서버가 `08:00` 이상 `24:00` 이하 `HH:MM` 형식과 시간 비감소 조건을 검증한 뒤 반영합니다.
+- LLM 제안이 누락되거나 유효하지 않아도 수정 결과는 실패시키지 않고 공용 fallback 분배 정책으로 보정합니다.
+- `planning_preference == SPONTANEOUS`이면 visit_time LLM 제안은 호출하지 않고 section label 기반 값을 사용합니다.
 - 콜백 전송 기본 타임아웃은 `CALLBACK_TIMEOUT_SECONDS`이며 기본값은 10초입니다.
 - 콜백 전송은 timeout, connection error, HTTP 429, HTTP 5xx에 대해 재시도합니다.
 

--- a/docs/architecture/roadmap-generation-server-communication.md
+++ b/docs/architecture/roadmap-generation-server-communication.md
@@ -172,9 +172,9 @@ sequenceDiagram
 - 생성 결과의 하루별 장소 순서는 `place_category == FOOD` 장소를 hard anchor로 고정하고, anchor 사이의 비음식 장소만 Haversine 직선거리 기반으로 재정렬한 결과입니다.
 - 동선 최적화는 Mohaeng-AI 내부 결정론적 알고리즘으로 수행하며, Google Routes API나 Distance Matrix API를 호출하지 않습니다.
 - 최종 `visit_sequence`와 `visit_time`은 동선 최적화 후 다시 계산합니다.
-- `visit_time`은 좌표 기반 이동시간을 계산하지 않고, 최종 `visit_sequence` 기반 고정 슬롯을 사용합니다.
-- `planning_preference`가 `PLANNED`이면 `1 -> 09:00`, `2 -> 12:00`, `3 -> 14:00`, `4 -> 18:00`, `5 -> 20:00`, `6 -> 22:00`, `7 이상 -> 23:00` 매핑을 사용합니다.
-- `planning_preference`가 `SPONTANEOUS`이면 같은 순서 매핑을 section label 형식으로 변환합니다.
+- `visit_time`은 좌표 기반 이동시간을 계산하지 않고, 최종 `visit_sequence`와 장소 수를 기준으로 공용 fallback 분배 정책을 사용합니다.
+- `planning_preference`가 `PLANNED`이면 `08:00` 이상 `24:00` 이하의 `HH:MM` 값을 사용합니다.
+- `planning_preference`가 `SPONTANEOUS`이면 같은 fallback 분배 결과를 section label 형식으로 변환합니다.
 - Google Places 원본 `primary_type`과 식사 anchor 판단값 같은 내부 힌트는 콜백에 포함하지 않습니다.
 - 콜백 전송 기본 타임아웃은 `CALLBACK_TIMEOUT_SECONDS`이며 기본값은 10초입니다.
 - 콜백 전송은 timeout, connection error, HTTP 429, HTTP 5xx에 대해 재시도합니다.

--- a/docs/specs/roadmap-chat-modification.md
+++ b/docs/specs/roadmap-chat-modification.md
@@ -121,14 +121,17 @@ REPLACE/ADD 검색어에는 현재 일자의 주소에서 추출한 지역 힌�
 
 ### 4. `propose_visit_time`
 
-수정된 일자의 장소 목록을 기준으로 LLM이 방문 시간 후보를 제안합니다.
-제안은 최종 확정값이 아니라 다음 `cascade` 단계의 공용 시간 정책 입력으로 사용됩니다.
+`planning_preference == PLANNED`인 경우에만 수정된 일자의 장소 목록을 기준으로 LLM이 방문 시간 후보를 제안합니다.
+LLM 제안은 다음 `cascade` 단계에서 형식, 허용 범위, 방문 순서 기준 시간 비감소 조건을 검증한 뒤 최종 `visit_time` 결정값으로 사용됩니다.
+`SPONTANEOUS` 로드맵에서는 이 노드가 LLM을 호출하지 않고 빈 proposal을 반환합니다.
 
 ### 5. `cascade`
 
 변경된 일자만 대상으로 방문 시간과 순서를 재정렬하고 제약을 검증합니다.
-`planning_preference`가 `PLANNED`이면 `HH:MM` 형식을, `SPONTANEOUS`이면 section 기반 값을 사용합니다.
-시간 계산과 경고 생성은 공용 visit time policy를 사용합니다.
+`planning_preference`가 `PLANNED`이면 `08:00` 이상 `24:00` 이하의 `HH:MM` 형식을 사용하고, LLM 제안이 누락되거나 유효하지 않은 구간은 서버 fallback으로 보정합니다.
+`24:00`은 유효한 종료 시각으로 허용하지만 `24:01` 이상은 거부합니다.
+`SPONTANEOUS`이면 LLM 제안 없이 section 기반 값을 사용합니다.
+시간 검증, fallback, 경고 생성은 공용 visit time policy를 사용합니다.
 
 ### 6. `respond`
 

--- a/docs/specs/roadmap-generation.md
+++ b/docs/specs/roadmap-generation.md
@@ -130,8 +130,9 @@ LLM은 특정 상호명 대신 `section`, `area`, `keyword` 중심의 검색용 
 - 설명 생성 실패 또는 타임아웃 시 기본 설명을 적용합니다.
 - 최적화된 순서 기준으로 `visit_sequence`를 1부터 다시 부여합니다.
 - `visit_time`은 최종 `visit_sequence`와 `planning_preference` 기준으로 `app/core/visit_time_policy.py` 정책을 적용해 재계산합니다.
-- `planning_preference == PLANNED`이면 `1 -> 09:00`, `2 -> 12:00`, `3 -> 14:00`, `4 -> 18:00`, `5 -> 20:00`, `6 -> 22:00`, `7 이상 -> 23:00` 매핑을 사용합니다.
-- `planning_preference == SPONTANEOUS`이면 같은 순서 매핑을 `MORNING`/`LUNCH` 같은 section label로 변환해 출력합니다.
+- 로드맵 생성 파이프라인은 별도 visit_time LLM 제안을 호출하지 않고, 공용 fallback 분배 정책으로 `08:00` 이상 `24:00` 이하의 값을 생성합니다.
+- `planning_preference == PLANNED`이면 fallback 분배 결과를 `HH:MM`으로 출력합니다.
+- `planning_preference == SPONTANEOUS`이면 fallback 분배 결과를 `MORNING`/`LUNCH` 같은 section label로 변환해 출력합니다.
 - `visit_time` 재계산은 좌표 기반 이동시간, 체류시간, 자정 초과 검증을 수행하지 않습니다.
 - LLM으로 `title`, `summary`, `tags`, `llm_commentary`를 생성합니다.
 - `next_action_suggestion`은 LLM 결과를 그대로 쓰지 않고 시스템에서 지원 가능한 문장만 안전하게 주입합니다.

--- a/tests/test_roadmap_generation_simplified_pipeline.py
+++ b/tests/test_roadmap_generation_simplified_pipeline.py
@@ -190,7 +190,7 @@ def test_prepare_final_context_reorders_places_and_recalculates_planned_visit_ti
     places = daily_places[0]["places"]
     assert [place["place_name"] for place in places] == ["A", "C", "B"]
     assert [place["visit_sequence"] for place in places] == [1, 2, 3]
-    assert [place["visit_time"] for place in places] == ["09:00", "12:00", "14:00"]
+    assert [place["visit_time"] for place in places] == ["09:00", "14:00", "19:00"]
     assert "#2" in itinerary_context
     assert "C" in itinerary_context
 

--- a/tests/test_visit_time_policy.py
+++ b/tests/test_visit_time_policy.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import importlib
+
 from app.core.visit_time_policy import VisitTimeOutputMode, apply_visit_time_policy
+from app.schemas.enums import PlanningPreference
 
 
 def _places() -> list[dict]:
@@ -17,37 +21,97 @@ def _places() -> list[dict]:
     ]
 
 
-def test_apply_visit_time_policy_maps_sequence_to_hhmm_without_transit_warnings() -> None:
+def _ten_places() -> list[dict]:
+    return [{"place_name": chr(65 + index), "visit_sequence": index + 1} for index in range(10)]
+
+
+def test_apply_visit_time_policy_uses_even_hhmm_fallback_without_transit_warnings() -> None:
     places, warnings = apply_visit_time_policy(_places(), output_mode=VisitTimeOutputMode.HHMM)
 
-    assert [place["visit_time"] for place in places] == ["09:00", "12:00", "14:00", "18:00", "20:00", "22:00", "23:00"]
+    assert [place["visit_time"] for place in places] == [
+        "09:00",
+        "11:08",
+        "13:16",
+        "15:24",
+        "17:32",
+        "19:40",
+        "21:48",
+    ]
     assert warnings == []
 
 
-def test_apply_visit_time_policy_maps_sequence_to_section_labels() -> None:
+def test_apply_visit_time_policy_maps_fallback_to_section_labels() -> None:
     places, warnings = apply_visit_time_policy(_places(), output_mode=VisitTimeOutputMode.SECTION_EN)
 
     assert [place["visit_time"] for place in places] == [
         "MORNING",
         "LUNCH",
+        "LUNCH",
+        "AFTERNOON",
         "AFTERNOON",
         "DINNER",
         "EVENING",
-        "NIGHT",
-        "NIGHT",
     ]
     assert warnings == []
 
 
-def test_apply_visit_time_policy_clamps_sequences_after_last_slot() -> None:
-    places = [*_places(), {"place_name": "H", "visit_sequence": 8}]
+def test_apply_visit_time_policy_does_not_clamp_eighth_to_tenth_hhmm_slots() -> None:
+    places, warnings = apply_visit_time_policy(_ten_places(), output_mode=VisitTimeOutputMode.HHMM)
 
-    hhmm_places, hhmm_warnings = apply_visit_time_policy(places, output_mode=VisitTimeOutputMode.HHMM)
-    section_places, section_warnings = apply_visit_time_policy(
-        _places() + [{"place_name": "H", "visit_sequence": 8}], output_mode=VisitTimeOutputMode.SECTION_EN
+    assert [place["visit_time"] for place in places] == [
+        "09:00",
+        "10:30",
+        "12:00",
+        "13:30",
+        "15:00",
+        "16:30",
+        "18:00",
+        "19:30",
+        "21:00",
+        "22:30",
+    ]
+    assert warnings == []
+
+
+def test_apply_visit_time_policy_uses_valid_llm_proposals_for_planned_output() -> None:
+    places, warnings = apply_visit_time_policy(
+        _places()[:3],
+        day_number=1,
+        llm_proposals_by_sequence={1: "08:30", 2: "12:15", 3: "24:00"},
+        output_mode=VisitTimeOutputMode.HHMM,
     )
 
-    assert hhmm_places[-1]["visit_time"] == "23:00"
-    assert section_places[-1]["visit_time"] == "NIGHT"
-    assert hhmm_warnings == []
-    assert section_warnings == []
+    assert [place["visit_time"] for place in places] == ["08:30", "12:15", "24:00"]
+    assert warnings == []
+
+
+def test_apply_visit_time_policy_rejects_out_of_range_or_decreasing_llm_proposals() -> None:
+    places, warnings = apply_visit_time_policy(
+        _places()[:4],
+        day_number=2,
+        llm_proposals_by_sequence={1: "07:59", 2: "10:00", 3: "09:30", 4: "24:01"},
+        output_mode=VisitTimeOutputMode.HHMM,
+    )
+
+    assert [place["visit_time"] for place in places] == ["09:00", "10:00", "16:30", "20:15"]
+    assert len(warnings) == 3
+
+
+def test_propose_visit_time_skips_llm_for_spontaneous_itinerary(monkeypatch) -> None:
+    async def _unexpected_call(*args, **kwargs):  # pragma: no cover - should never run
+        raise AssertionError("SPONTANEOUS should not call visit time LLM")
+
+    propose_module = importlib.import_module("app.graph.chat.nodes.propose_visit_time")
+    monkeypatch.setattr(propose_module, "propose_visit_times_for_days", _unexpected_call)
+
+    state = {
+        "modified_itinerary": {
+            "planning_preference": PlanningPreference.SPONTANEOUS,
+            "itinerary": [{"day_number": 1, "places": _places()[:1]}],
+        },
+        "diff_keys": ["day1_place1"],
+    }
+
+    result = asyncio.run(propose_module.propose_visit_time(state))
+
+    assert result["visit_time_proposals"] == {}

--- a/tests/test_visit_time_policy.py
+++ b/tests/test_visit_time_policy.py
@@ -6,6 +6,7 @@ import asyncio
 import importlib
 
 from app.core.visit_time_policy import VisitTimeOutputMode, apply_visit_time_policy
+from app.graph.chat.nodes.cascade import cascade
 from app.schemas.enums import PlanningPreference
 
 
@@ -23,6 +24,39 @@ def _places() -> list[dict]:
 
 def _ten_places() -> list[dict]:
     return [{"place_name": chr(65 + index), "visit_sequence": index + 1} for index in range(10)]
+
+
+def _roadmap(planning_preference: PlanningPreference, places: list[dict]) -> dict:
+    return {
+        "start_date": "2026-02-11",
+        "end_date": "2026-02-11",
+        "trip_days": 1,
+        "nights": 0,
+        "people_count": 2,
+        "tags": ["도심"],
+        "title": "서울 일정",
+        "summary": "서울 당일 일정입니다.",
+        "planning_preference": planning_preference,
+        "itinerary": [{"day_number": 1, "daily_date": "2026-02-11", "places": places}],
+    }
+
+
+def _course_places(count: int) -> list[dict]:
+    return [
+        {
+            "place_name": f"장소 {index}",
+            "place_id": f"place-{index}",
+            "address": "서울",
+            "latitude": 37.5,
+            "longitude": 127.0,
+            "place_url": "https://maps.example.com",
+            "place_category": "OTHER",
+            "description": "방문 장소입니다.",
+            "visit_sequence": index,
+            "visit_time": "09:00",
+        }
+        for index in range(1, count + 1)
+    ]
 
 
 def test_apply_visit_time_policy_uses_even_hhmm_fallback_without_transit_warnings() -> None:
@@ -83,6 +117,34 @@ def test_apply_visit_time_policy_uses_valid_llm_proposals_for_planned_output() -
 
     assert [place["visit_time"] for place in places] == ["08:30", "12:15", "24:00"]
     assert warnings == []
+
+
+def test_cascade_applies_llm_visit_time_proposals_to_modified_planned_day() -> None:
+    state = {
+        "modified_itinerary": _roadmap(PlanningPreference.PLANNED, _course_places(3)),
+        "diff_keys": ["day1_place1"],
+        "visit_time_proposals": {1: {1: "08:00", 2: "12:00", 3: "24:00"}},
+    }
+
+    result = cascade(state)
+    places = result["modified_itinerary"]["itinerary"][0]["places"]
+
+    assert [place["visit_time"] for place in places] == ["08:00", "12:00", "24:00"]
+    assert result.get("warnings", []) == []
+
+
+def test_cascade_keeps_spontaneous_output_as_section_labels_without_llm_times() -> None:
+    state = {
+        "modified_itinerary": _roadmap(PlanningPreference.SPONTANEOUS, _course_places(3)),
+        "diff_keys": ["day1_place1"],
+        "visit_time_proposals": {1: {1: "08:00", 2: "12:00", 3: "24:00"}},
+    }
+
+    result = cascade(state)
+    places = result["modified_itinerary"]["itinerary"][0]["places"]
+
+    assert [place["visit_time"] for place in places] == ["MORNING", "AFTERNOON", "DINNER"]
+    assert result.get("warnings", []) == []
 
 
 def test_apply_visit_time_policy_rejects_out_of_range_or_decreasing_llm_proposals() -> None:


### PR DESCRIPTION
## 1. 개요
- 관련 이슈: #95

## 2. 작업 내용
- `PLANNED` 채팅 수정에서 LLM visit_time proposal을 최종 결정값으로 반영하도록 공용 정책을 변경했습니다.
- `08:00~24:00` HH:MM 형식, `24:00` 허용, 시간 비감소 조건을 검증하고 누락/오류 구간은 fallback으로 보정합니다.
- `SPONTANEOUS` 채팅 수정에서는 visit_time LLM 호출을 스킵하고 section label 기반 정책을 유지합니다.
- 관련 정책/프롬프트/문서와 visit_time 단위 및 cascade 테스트를 갱신했습니다.

## 3. AI 활용 및 검증
- [x] AI가 생성한 코드 포함
- [ ] 100% 직접 작성

- 검증 방법:
  - `docker exec mohaeng pytest tests/test_visit_time_policy.py tests/test_roadmap_generation_simplified_pipeline.py tests/test_chat_schema.py`
  - `docker exec mohaeng ruff check .`
  - `docker exec mohaeng ruff format --check .`

## 4. 스크린샷 (선택)

## 5. 체크리스트
- [x] `uv run pre-commit run --all-files`를 실행하여 통과했는가?
- [x] 스스로 코드를 한 번 리뷰했는가? (AI가 짠 코드 맹신 금지)
- [x] 불필요한 주석이나 print 문을 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 방문 시간 제안이 08:00~24:00 범위로 제한되어 더욱 현실적인 일정을 제공합니다.

* **버그 수정**
  * 유효하지 않거나 누락된 방문 시간 제안에 대한 자동 보정 기능이 추가되었습니다.

* **문서**
  * API 및 아키텍처 문서가 업데이트되어 방문 시간 관련 정책이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->