### PR TITLE
[Fix] 로드맵 장소 중복 문제 해결

### DIFF
--- a/app/graph/roadmap/nodes/finalize.py
+++ b/app/graph/roadmap/nodes/finalize.py
@@ -46,18 +46,53 @@ async def _notify_pipeline_event_best_effort(**kwargs) -> None:
         )
 
 
-def _select_place_in_region(places: list[dict], region_bbox: GeoRectangle | None) -> dict | None:
-    """bbox 내 첫 번째 장소를 반환합니다. bbox 내 장소가 없으면 None을 반환합니다."""
+def _place_dedupe_key(place: dict) -> str | None:
+    """장소 중복 제거용 키를 생성합니다."""
+    place_id = str(place.get("place_id") or "").strip()
+    if place_id:
+        return f"id:{place_id}"
+
+    name = str(place.get("display_name") or place.get("name") or place.get("place_name") or "").strip()
+    address = str(place.get("address") or "").strip()
+    normalized_name = " ".join(name.split()).lower()
+    normalized_address = " ".join(address.split()).lower()
+    if normalized_name or normalized_address:
+        return f"name:{normalized_name}|address:{normalized_address}"
+    return None
+
+
+def _select_place_in_region(
+    places: list[dict],
+    region_bbox: GeoRectangle | None,
+    used_place_keys: set[str],
+) -> tuple[dict | None, str | None, bool]:
+    """bbox 내에서 아직 쓰이지 않은 첫 번째 장소를 반환합니다."""
     if not places:
-        return None
+        return None, None, False
     if not region_bbox:
-        return places[0]
+        for place in places:
+            place_key = _place_dedupe_key(place)
+            if place_key and place_key not in used_place_keys:
+                return place, place_key, False
+        fallback_place = places[0]
+        fallback_key = _place_dedupe_key(fallback_place)
+        return fallback_place, fallback_key, bool(fallback_key and fallback_key in used_place_keys)
+
+    fallback_place: dict | None = None
+    fallback_key: str | None = None
     for place in places:
         geometry = place.get("geometry") or {}
         lat = geometry.get("latitude")
         lng = geometry.get("longitude")
         if lat is not None and lng is not None and region_bbox.contains(lat, lng):
-            return place
+            place_key = _place_dedupe_key(place)
+            if place_key and place_key not in used_place_keys:
+                return place, place_key, False
+            if fallback_place is None:
+                fallback_place = place
+                fallback_key = place_key
+    if fallback_place is not None:
+        return fallback_place, fallback_key, bool(fallback_key and fallback_key in used_place_keys)
     logger.warning(
         "No place found within region bbox: candidate_count=%d bbox=(%s,%s)-(%s,%s)",
         len(places),
@@ -66,7 +101,7 @@ def _select_place_in_region(places: list[dict], region_bbox: GeoRectangle | None
         region_bbox.max_lat,
         region_bbox.max_lng,
     )
-    return None
+    return None, None, False
 
 
 class PlaceDetailSlot(BaseModel):
@@ -177,6 +212,8 @@ def _prepare_final_context(
         raise ValueError(f"CourseRequest 모델 유효성 검증에 실패했습니다: {exc}") from exc
 
     daily_places_for_schema = []
+    used_place_keys: set[str] = set()
+    duplicate_fallback_count = 0
     for day_plan in skeleton_plan:
         day_number = day_plan["day_number"]
         day_region = day_plan.get("region")
@@ -189,9 +226,13 @@ def _prepare_final_context(
             slot_key = build_slot_key(day_number, i)
             places = fetched_places.get(slot_key, [])
             if places:
-                place = _select_place_in_region(places, day_region_bbox)
+                place, place_key, duplicate_fallback = _select_place_in_region(places, day_region_bbox, used_place_keys)
                 if place is None:
                     continue
+                if place_key:
+                    used_place_keys.add(place_key)
+                if duplicate_fallback:
+                    duplicate_fallback_count += 1
                 section = slot.get("section")
                 display_name = place.get("display_name") or place["name"]
 
@@ -245,6 +286,9 @@ def _prepare_final_context(
             output_mode=VisitTimeOutputMode.HHMM,
         )
         day["places"] = resolved_places
+
+    if duplicate_fallback_count:
+        append_job_log("route_dedupe", f"duplicate_fallback_count={duplicate_fallback_count}")
 
     return _build_itinerary_context(daily_places_for_schema), daily_places_for_schema
 

--- a/app/graph/roadmap/nodes/skeleton.py
+++ b/app/graph/roadmap/nodes/skeleton.py
@@ -323,6 +323,7 @@ def _build_segment_prompt(
         "- keyword는 8~40자 사이로 작성하고, 한 단어 대신 구체 맥락(활동+대상+분위기)을 포함하세요\n"
         "- 예시: '한강 야경 산책 코스', '로컬 해산물 저녁 식사', '현대미술 전시 관람'\n"
         "- '맛집', '카페', '쇼핑' 같은 단일 범주형 단어만 쓰지 마세요\n"
+        "- Google Place API 후보는 동일 place_id가 다른 슬롯/일자에 중복되지 않도록 가능한 다른 후보를 선택하세요\n"
         "{priority_notes_rules}"
         "- 출력은 스키마를 정확히 따라야 하며 추가 텍스트는 금지합니다\n"
     ).format(
@@ -358,6 +359,7 @@ def _build_segment_prompt(
         "- section은 다음 중 하나여야 합니다 MORNING, LUNCH, AFTERNOON, DINNER, EVENING, NIGHT\n\n"
         "- '최우선 사용자 메모'가 있으면 모든 day에서 그 의도가 보이도록 슬롯을 설계하세요\n"
         "- 특히 포함/제외 대상, 분위기, 속도감, 동선 톤 같은 자유 입력 요구를 일반 선호보다 먼저 반영하세요\n\n"
+        "- Google Place API 후보는 동일 place_id가 다른 슬롯/일자에 중복되지 않도록 가능한 다른 후보를 선택하세요\n\n"
         "{format_instructions}"
     )
 
@@ -402,6 +404,7 @@ def _build_repair_prompt(
     system_prompt = (
         "당신은 여행 스켈레톤 JSON 복구 전문가입니다.\n"
         "입력으로 주어진 JSON의 형식/제약 위반만 수정하고 의도는 최대한 유지하세요.\n"
+        "Google Place API 후보는 동일 place_id가 다른 슬롯/일자에 중복되지 않도록 가능한 다른 후보를 선택하세요.\n"
         "반드시 JSON만 출력하고, 설명 텍스트는 절대 포함하지 마세요."
     )
     user_prompt = (
@@ -412,7 +415,8 @@ def _build_repair_prompt(
         "필수 section: MORNING, LUNCH, AFTERNOON, DINNER, EVENING, NIGHT\n"
         "추가 제약: 좌표/전화번호/P.O. Box/C/O/상세 주소 금지, keyword는 8~40자\n"
         "keyword는 Text Search textQuery로 직접 쓰이므로 구체 맥락(활동+대상+분위기)을 포함\n"
-        "'맛집/카페/쇼핑' 같은 단일 범주 단어만 사용 금지\n\n"
+        "'맛집/카페/쇼핑' 같은 단일 범주 단어만 사용 금지\n"
+        "Google Place API 후보는 동일 place_id가 다른 슬롯/일자에 중복되지 않도록 가능한 다른 후보를 선택\n\n"
         "원본 요청 요약:\n"
         "- 전체 일정: {start_date} ~ {end_date}\n"
         "- 인원: {people_count}\n"

--- a/tests/test_roadmap_generation_simplified_pipeline.py
+++ b/tests/test_roadmap_generation_simplified_pipeline.py
@@ -229,6 +229,72 @@ def test_prepare_final_context_uses_hhmm_baseline_for_spontaneous_visit_time() -
     assert place["visit_time"] == "09:00"
 
 
+def test_prepare_final_context_skips_duplicate_place_ids_across_days() -> None:
+    state = {
+        "course_request": {
+            **_base_course_request(),
+            "end_date": "2026-02-02",
+        },
+        "trip_days": 2,
+        "slot_min": 1,
+        "slot_max": 1,
+        "skeleton_plan": [
+            {
+                "day_number": 1,
+                "region": "SEOUL",
+                "slots": [{"section": "MORNING", "area": "중심가", "keyword": "museum"}],
+            },
+            {
+                "day_number": 2,
+                "region": "SEOUL",
+                "slots": [{"section": "MORNING", "area": "중심가", "keyword": "museum"}],
+            },
+        ],
+        "fetched_places": {
+            "day1_slot0": [
+                {
+                    "place_id": "place-1",
+                    "name": "A",
+                    "address": "서울 종로구",
+                    "geometry": {"latitude": 37.5796, "longitude": 126.977},
+                    "primary_type": "museum",
+                    "types": ["museum"],
+                },
+                {
+                    "place_id": "place-2",
+                    "name": "B",
+                    "address": "서울 종로구",
+                    "geometry": {"latitude": 37.58, "longitude": 126.978},
+                    "primary_type": "park",
+                    "types": ["park"],
+                },
+            ],
+            "day2_slot0": [
+                {
+                    "place_id": "place-1",
+                    "name": "A",
+                    "address": "서울 종로구",
+                    "geometry": {"latitude": 37.5796, "longitude": 126.977},
+                    "primary_type": "museum",
+                    "types": ["museum"],
+                },
+                {
+                    "place_id": "place-2",
+                    "name": "B",
+                    "address": "서울 종로구",
+                    "geometry": {"latitude": 37.58, "longitude": 126.978},
+                    "primary_type": "park",
+                    "types": ["park"],
+                },
+            ],
+        },
+    }
+
+    _, daily_places = _prepare_final_context(state)
+
+    assert [place["place_id"] for day in daily_places for place in day["places"]] == ["place-1", "place-2"]
+
+
 def test_segment_prompt_prioritizes_user_notes_when_present() -> None:
     request = CourseRequest.model_validate(
         {
@@ -256,6 +322,8 @@ def test_segment_prompt_prioritizes_user_notes_when_present() -> None:
     assert "조용한 동선으로 구성하고 붐비는 관광지는 제외해 주세요." in user_content
     assert "다른 일반 선호값보다 우선해서 해석" in system_content
     assert "일반 선호보다 먼저 반영" in user_content
+    assert "동일 place_id" in system_content
+    assert "동일 place_id" in user_content
 
 
 def test_finalize_summary_prompt_prioritizes_user_notes() -> None:


### PR DESCRIPTION
## 1. 개요
- 관련 이슈: #107
- 로드맵 생성 시 동일 `place_id`가 여러 슬롯/일자에 반복 배정되는 문제를 줄입니다.

## 2. 작업 내용
- `finalize` 단계에서 `place_id` 기준 전역 중복 제거를 추가했습니다.
- 중복 후보밖에 남지 않은 경우에도 가능한 대체 후보를 우선 선택하도록 했습니다.
- `skeleton` 생성 및 복구 프롬프트에 동일 `place_id` 중복 금지 지시를 추가했습니다.
- 관련 단위 테스트를 추가해 날짜를 넘어가는 중복 재사용 케이스를 검증했습니다.

## 3. AI 사용 및 검증
- [x] AI가 생성한 코드 포함
- [ ] 100% 수동 작성
- 검증 방법: `git diff --check`
- 테스트: 현재 셸 환경에 `uv`/`pytest`가 없어 자동 테스트는 실행하지 못했습니다.

## 4. 스크린샷
- 해당 없음

## 5. 체크리스트
- [x] `uv run pre-commit run --all-files`를 실행했는가?
- [x] 관련 테스트를 실행했는가? (현재 환경에서는 실행 불가)
- [x] 불필요한 print나 디버그 코드를 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 루트 계획 시 여러 날짜와 슬롯에서 동일한 장소가 중복으로 추천되는 문제를 개선했습니다. 시스템이 더 다양한 장소를 선택하도록 로직을 강화했으며, 필요시에만 대체 장소를 사용하게 됩니다.

* **테스트**
  * 중복 제거 기능의 안정성을 검증하는 새로운 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->